### PR TITLE
Allow setting of conda channels to install package dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+v0.0.1
+* Change order of conda env setup so that built package is installed before packages in the environment.yml are.
+* Add package_conda_channels variable which sets the conda channels used when installing the built package.
+* Add build_subdir_name variable which sets where the docs htmls are saved within docs/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@ v0.0.1
 * Change order of conda env setup so that built package is installed before packages in the environment.yml are.
 * Add package_conda_channels variable which sets the conda channels used when installing the built package.
 * Add build_subdir_name variable which sets where the docs htmls are saved within docs/build
+* conda environment by default installs python 3.7

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         source ${{ inputs.base_env_prefix }}/etc/profile.d/conda.sh
         echo "-----------------"
 
-        conda create -n ${{ github.event.repository.name }}-build
+        conda create -n ${{ github.event.repository.name }}-build python=3.7 -c conda-forge
         conda activate ${{ github.event.repository.name }}-build
         conda install conda-build
         ls -al ${{ inputs.package_folder_path }}

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,10 @@ runs:
         echo "conda list"
         conda list
 
+        
+        cd /usr/share/miniconda/envs/CIL-build/lib/python3.7/site-packages/cil
+        ls -R
+
         echo ""
         echo "BUILD DOCS"
         echo "----------"

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'conda channels needed to install package. Spearate each channel with -c.'
     required: False
     default: conda-forge
+  build_folder_name:
+    description: 'docs will be built inside docs_path in a folder with this name.'
+    required: False
+    default: 'build/html'
 outputs:
   filepath:
     description: 'The file path of the generated HTML documentation'
@@ -120,13 +124,13 @@ runs:
         if [ -e "./setup_source.sh" ]; then
           ./setup_source.sh
         fi
-        make html
-        echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/build/html')"
+        sphinx-build source ${{ inputs.build_folder_name }}
+        echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/${{ inputs.build_folder_name }')"
       shell: bash -l {0}
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.artifact_name }}
-        path: ${{ inputs.docs_path }}/build/html
+        path: ${{ inputs.docs_path }}/${{ inputs.build_folder_name}
 branding:
   icon: 'book-open'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         source ${{ inputs.base_env_prefix }}/etc/profile.d/conda.sh
         echo "-----------------"
 
-        conda create -n 
+        conda create -n ${{ github.event.repository.name }}-build
         conda activate ${{ github.event.repository.name }}-build
         conda install conda-build
         ls -al ${{ inputs.package_folder_path }}

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
         source ${{ inputs.base_env_prefix }}/etc/profile.d/conda.sh
         echo "-----------------"
 
-        conda create -n ${{ github.event.repository.name }}-build
+        conda create -n ${{ github.event.repository.name }}-build python=3.7 -c conda-forge
         conda activate ${{ github.event.repository.name }}-build
         conda install conda-build
         ls -al ${{ inputs.package_folder_path }}

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
         source ${{ inputs.base_env_prefix }}/etc/profile.d/conda.sh
         echo "-----------------"
 
-        conda create -n ${{ github.event.repository.name }}-build python=3.7 -c conda-forge
+        conda create -n ${{ github.event.repository.name }}-build
         conda activate ${{ github.event.repository.name }}-build
         conda install conda-build
         ls -al ${{ inputs.package_folder_path }}

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,7 @@ runs:
         conda list
 
         
-        cd /usr/share/miniconda/envs/CIL-build/lib/python3.7/site-packages/cil
-        ls -R
+        cat /usr/share/miniconda/envs/CIL-build/lib/python3.7/site-packages/cil/version.py
 
         echo ""
         echo "BUILD DOCS"

--- a/action.yml
+++ b/action.yml
@@ -114,9 +114,6 @@ runs:
         echo "conda list"
         conda list
 
-        
-        cat /usr/share/miniconda/envs/CIL-build/lib/python3.7/site-packages/cil/version.py
-
         echo ""
         echo "BUILD DOCS"
         echo "----------"

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ inputs:
     description: 'conda channels needed to install package. Spearate each channel with -c.'
     required: False
     default: conda-forge
-  build_folder_name:
-    description: 'docs will be built inside docs_path in a folder with this name.'
+  build_subdir_name:
+    description: 'docs will be built inside docs_path in build/{build_subdir_name}.'
     required: False
-    default: 'build/html'
+    default: 'html'
 outputs:
   filepath:
     description: 'The file path of the generated HTML documentation'
@@ -124,13 +124,13 @@ runs:
         if [ -e "./setup_source.sh" ]; then
           ./setup_source.sh
         fi
-        sphinx-build source ${{ inputs.build_folder_name }}
-        echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/${{ inputs.build_folder_name }')"
+        sphinx-build source build/${{ inputs.build_subdir_name }}
+        echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/build')"
       shell: bash -l {0}
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.artifact_name }}
-        path: ${{ inputs.docs_path }}/${{ inputs.build_folder_name}
+        path: ${{ inputs.docs_path }}/build
 branding:
   icon: 'book-open'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Name of the project''s Conda package'
     required: false
     default: ${{ github.event.repository.name }}
+  package_conda_channels:
+    description: 'conda channels needed to install package. Spearate each channel with -c.'
+    required: False
+    default: conda-forge
 outputs:
   filepath:
     description: 'The file path of the generated HTML documentation'
@@ -48,6 +52,7 @@ runs:
         fi
         echo ""
         echo "Selecting Build Env yml File"
+
         if [ ${{ inputs.conda_build_env_filepath }} = 'action_default' ]; then
           echo "Using the default conda configuration"
           CONDA_BUILD_ENV_FILE="${{ github.action_path }}/envs/build-docs.yml"
@@ -77,10 +82,8 @@ runs:
         echo "Set source"
         source ${{ inputs.base_env_prefix }}/etc/profile.d/conda.sh
         echo "-----------------"
-        echo "Setting up ${{ github.event.repository.name }}-build environment"
-        conda env update --name ${{ github.event.repository.name }}-build \
-                         --file "${CONDA_BUILD_ENV_FILE}"  || \
-            conda env create -f "${CONDA_BUILD_ENV_FILE}"
+
+        conda create -n 
         conda activate ${{ github.event.repository.name }}-build
         conda install conda-build
         ls -al ${{ inputs.package_folder_path }}
@@ -91,10 +94,15 @@ runs:
           mkdir -p "${CHANNEL_PATH}"
           cp ${{ inputs.package_folder_path }}/${{ inputs.package_name }}-*.bz2 ${CHANNEL_PATH}
           conda index "${CHANNEL_PATH}"
-          conda install -c "${CHANNEL_PATH}" ${{ inputs.package_name }}
+          conda install -c "${CHANNEL_PATH}" ${{ inputs.package_name }} -c ${{inputs.package_conda_channels}}
         else
           echo "Did not install project package"
         fi
+
+        echo "Setting up ${{ github.event.repository.name }}-build environment"
+        conda env update --name ${{ github.event.repository.name }}-build \
+                         --file "${CONDA_BUILD_ENV_FILE}"
+        
         echo ""
         echo "conda info"
         conda info
@@ -115,7 +123,7 @@ runs:
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.artifact_name }}
-        path: docs/build/html
+        path: ${{ inputs.docs_path }}/build/html
 branding:
   icon: 'book-open'
   color: 'blue'


### PR DESCRIPTION
* Change order of conda env setup so that built package is installed before packages in the environment.yml are.
* Add package_conda_channels variable which sets the conda channels used when installing the built package.
* Add build_subdir_name variable which sets where the docs htmls are saved within docs/build