### PR TITLE
update upload-artifact and download-artifact action versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.1.2
+* Updates actions/upload-artifact to v3.1.1
+* Updates actions/download-artifact to v3.0.1
+
 v0.1.1
 * Force install from artifact by setting version of package (by retrieving version string from tar.bz2 file)
 * Add print statements to show files being copied, conda channel being created, and version being retrieved

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3.0.1
       with:
         path: artifacts
     - id: main

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
         sphinx-build source build/${{ inputs.build_subdir_name }}
         echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/build')"
       shell: bash -l {0}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3.1.1
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.docs_path }}/build


### PR DESCRIPTION
see issues with the old version described here: https://github.com/TomographicImaging/CIL/issues/1380

Updates actions/upload-artifact to v3.1.1
Updates actions/download-artifact to v3.0.1