### PR TITLE
remove set-output use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.1.3
+* Remove use of set-output due to deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+
 v0.1.2
 * Updates actions/upload-artifact to v3.1.1
 * Updates actions/download-artifact to v3.0.1

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         path: artifacts
     - id: main
       run: |
-        echo "::set-output name=filepath::$(echo "None")"
+        echo  "filepath=$(echo "None") >> $GITHUB_OUTPUT"
         echo "CHECKS"
         echo "------"
         if [ -d ${{ inputs.docs_path }} ]; then
@@ -136,7 +136,7 @@ runs:
           ./setup_source.sh
         fi
         sphinx-build source build/${{ inputs.build_subdir_name }}
-        echo "::set-output name=filepath::$(echo '${{ inputs.docs_path }}/build')"
+        echo "filepath=$(echo '${{ inputs.docs_path }}/build') >> $GITHUB_OUTPUT"
       shell: bash -l {0}
     - uses: actions/upload-artifact@v3.1.1
       with:


### PR DESCRIPTION
This is required due to deprecation, explained here:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/